### PR TITLE
Replace CTRL+SHIFT+1/2 with CTRL+SHIFT+SPACE

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,6 @@ function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow(config)
   mainWindow.setMenu(null)
-
   // Set always on top
   if (process.platform == 'darwin')
     app.dock.hide()
@@ -72,11 +71,8 @@ function createWindow() {
     utils.resetWindowToFloat(mainWindow);
   })
 
-  globalShortcut.register('CommandOrControl+Shift+1', () => {
-    mainWindow.webContents.send('pause', 'ping')
-  })
-  globalShortcut.register('CommandOrControl+Shift+2', () => {
-    mainWindow.webContents.send('play', 'ping')
+  globalShortcut.register('CommandOrControl+Shift+Space', () => {
+    mainWindow.webContents.send('togglePlay', 'ping')
   })
   globalShortcut.register('Alt+Shift+F', () => {
     fullscreenToggle(mainWindow, false)

--- a/renderer.js
+++ b/renderer.js
@@ -43,17 +43,14 @@ async function putYoutube(videoId) {
   });
 }
 
-function pause() {
+function togglePlay() {
   if (player) {
-    player.pauseVideo()
-  } else {
-    alert("Play a video first");
-  }
-}
-
-function play() {
-  if (player) {
-    player.playVideo()
+    if(player.getPlayerState() == 1) {
+        player.pauseVideo()
+    } else if (player.getPlayerState() != 1) {
+        player.playVideo()
+    }
+    
   } else {
     alert("Play a video first");
   }
@@ -70,12 +67,8 @@ window.addEventListener('keyup', function(e){
     ipcRenderer.send('exit-full-screen')
 })
 
-ipcRenderer.on('pause', (ev, arg) => {
-  pause()
-})
-
-ipcRenderer.on('play', (ev, arg) => {
-  play()
+ipcRenderer.on('togglePlay', (ev, arg) => {
+  togglePlay()
 })
 
 ipcRenderer.on('youtube', (ev, arg) => {


### PR DESCRIPTION
Replaced play and pause shortcuts with single shortcut for toggling between play and pause: CTRL/COMMAND+SHIFT+SPACE
Fixes: #79